### PR TITLE
Codec improvements, fix #24, add Binary Set, String Set, Number Set codecs, zio.Has env encoding

### DIFF
--- a/d4s-circe/src/test/scala/d4s/codecs/Fixtures.scala
+++ b/d4s-circe/src/test/scala/d4s/codecs/Fixtures.scala
@@ -49,4 +49,14 @@ object Fixtures {
     implicit lazy val arbitrary: Arbitrary[TestDouble]  = MkArbitrary[TestDouble].arbitrary
   }
 
+  case class TestBinarySet(a: Set[Array[Byte]])
+  object TestBinarySet extends WithD4S[TestBinarySet] {
+    implicit lazy val arbitrary: Arbitrary[TestBinarySet] = MkArbitrary[TestBinarySet].arbitrary
+  }
+
+  case class TestStringSet(a: Set[String])
+  object TestStringSet extends WithD4S[TestStringSet] {
+    implicit lazy val arbitrary: Arbitrary[TestStringSet] = MkArbitrary[TestStringSet].arbitrary
+  }
+
 }

--- a/d4s/src/main/scala/d4s/DynamoConnectorLocal.scala
+++ b/d4s/src/main/scala/d4s/DynamoConnectorLocal.scala
@@ -1,54 +1,40 @@
 package d4s
 
-import d4s.DynamoConnectorLocal.WithDynamoConnector
 import d4s.metrics.{MacroMetricDynamoMeter, MacroMetricDynamoTimer}
 import d4s.models.query.DynamoRequest
 import d4s.models.{DynamoException, DynamoExecution}
 import fs2.Stream
 import izumi.functional.bio.{BIO3, BIOLocal, F}
+import izumi.reflect.Tags.Tag
 
-import scala.language.implicitConversions
-
-class DynamoConnectorLocal[F[-_, +_, +_]: BIO3: BIOLocal] extends DynamoConnector[F[WithDynamoConnector[F], +?, +?]] {
+class DynamoConnectorLocal[F[-_, +_, +_]: BIO3: BIOLocal](implicit tag: Tag[DynamoConnector3[F]]) extends DynamoConnector[F[HasDynamoConnector[F], +?, +?]] {
   override def runUnrecorded[DR <: DynamoRequest, A](
     q: DynamoExecution[DR, _, A]
-  ): F[WithDynamoConnector[F], DynamoException, A] = {
-    F.access(_.connector.runUnrecorded(q))
+  ): F[HasDynamoConnector[F], DynamoException, A] = {
+    F.access(_.get.runUnrecorded(q))
   }
 
   override def runUnrecorded[DR <: DynamoRequest, A](
     q: DynamoExecution.Streamed[DR, _, A]
-  ): Stream[F[WithDynamoConnector[F], Throwable, ?], A] = {
-    Stream.force[F[WithDynamoConnector[F], Throwable, ?], A] {
-      F.askWith(_.connector.runUnrecorded(q))
+  ): Stream[F[HasDynamoConnector[F], Throwable, ?], A] = {
+    Stream.force[F[HasDynamoConnector[F], Throwable, ?], A] {
+      F.askWith(_.get.runUnrecorded(q))
     }
   }
 
   override def run[DR <: DynamoRequest, Dec, A](label: String)(
     q: DynamoExecution[DR, Dec, A]
-  )(implicit macroTimeSaver: MacroMetricDynamoTimer[label.type], macroMeterSaver: MacroMetricDynamoMeter[label.type]): F[WithDynamoConnector[F], DynamoException, A] = {
-    F.access(_.connector.run(label)(q))
+  )(implicit macroTimeSaver: MacroMetricDynamoTimer[label.type], macroMeterSaver: MacroMetricDynamoMeter[label.type]): F[HasDynamoConnector[F], DynamoException, A] = {
+    F.access(_.get.run(label)(q))
   }
 
   override def runStreamed[DR <: DynamoRequest, Dec, A](label: String)(
     q: DynamoExecution.Streamed[DR, Dec, A]
   )(implicit macroTimeSaver: MacroMetricDynamoTimer[label.type],
-    macroMeterSaver: MacroMetricDynamoMeter[label.type]): Stream[F[WithDynamoConnector[F], DynamoException, ?], A] = {
+    macroMeterSaver: MacroMetricDynamoMeter[label.type]): Stream[F[HasDynamoConnector[F], DynamoException, ?], A] = {
     Stream
-      .force[F[WithDynamoConnector[F], DynamoException, ?], A] {
-        F.askWith(_.connector.runStreamed(label)(q))
+      .force[F[HasDynamoConnector[F], DynamoException, ?], A] {
+        F.askWith(_.get.runStreamed(label)(q))
       }
-  }
-}
-
-object DynamoConnectorLocal {
-  trait WithDynamoConnector[F[-_, +_, +_]] {
-    def connector: DynamoConnector[F[Any, +?, +?]]
-  }
-  object WithDynamoConnector {
-    def apply[F[-_, +_, +_]](conn: DynamoConnector[F[Any, +?, +?]]): WithDynamoConnector[F] = fromConnector(conn)
-    implicit def fromConnector[F[-_, +_, +_]](conn: DynamoConnector[F[Any, +?, +?]]): WithDynamoConnector[F] = new WithDynamoConnector[F] {
-      override def connector: DynamoConnector[F[Any, +*, +*]] = conn
-    }
   }
 }

--- a/d4s/src/main/scala/d4s/HasDynamoConnector.scala
+++ b/d4s/src/main/scala/d4s/HasDynamoConnector.scala
@@ -1,0 +1,12 @@
+package d4s
+
+import izumi.reflect.Tags.Tag
+import zio.Has
+
+import scala.language.implicitConversions
+
+object HasDynamoConnector {
+  def apply[F[-_, +_, +_]](connector: DynamoConnector3[F])(implicit tag: Tag[DynamoConnector3[F]]): HasDynamoConnector[F] = Has(connector)
+
+  implicit def fromConnector[F[-_, +_, +_]](connnector: DynamoConnector3[F])(implicit tag: Tag[DynamoConnector3[F]]): HasDynamoConnector[F] = Has(connnector)
+}

--- a/d4s/src/main/scala/d4s/codecs/D4SAttributeCodec.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SAttributeCodec.scala
@@ -7,11 +7,11 @@ import d4s.models.DynamoException.DecoderException
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 trait D4SAttributeCodec[A] extends D4SAttributeEncoder[A] with D4SDecoder[A] {
-  final def imap[B](to: A => B)(from: B => A): D4SAttributeCodec[B] = fromPair(contramap(from), map(to))
+  def imap[B](decode: A => B)(encode: B => A): D4SAttributeCodec[B] = fromPair(contramap(encode), map(decode))
 }
 
 object D4SAttributeCodec {
-  def apply[A: D4SAttributeCodec]: D4SAttributeCodec[A]                                    = implicitly
+  @inline def apply[A: D4SAttributeCodec]: D4SAttributeCodec[A]                            = implicitly
   def derived[A](implicit derivedCodec: D4SDerivedAttributeCodec[A]): D4SAttributeCodec[A] = D4SAttributeCodec.fromPair(derivedCodec.enc, derivedCodec.dec)
 
   def from[T: D4SAttributeEncoder: D4SDecoder]: D4SAttributeCodec[T] = fromPair(D4SAttributeEncoder[T], D4SDecoder[T])

--- a/d4s/src/main/scala/d4s/codecs/D4SCodec.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SCodec.scala
@@ -2,23 +2,33 @@ package d4s.codecs
 
 import java.util
 
-import d4s.codecs.D4SCodec.fromPair
+import d4s.codecs.D4SCodec.Imap2PartiallyApplied
 import d4s.models.DynamoException.DecoderException
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 trait D4SCodec[A] extends D4SAttributeCodec[A] with D4SEncoder[A] {
-  final def imap2[B, C](another: D4SCodec[B])(to: (A, B) => C)(from: C => (A, B)): D4SCodec[C] = {
-    fromPair(contramap2(another)(from), map2(another)(to))
+  override final def imap[B](decode: A => B)(encode: B => A): D4SCodec[B] = {
+    D4SCodec.fromPair(contramap(encode), map(decode))
   }
+  final def imap2[B, C](another: D4SCodec[B])(decode: (A, B) => C)(encode: C => (A, B)): D4SCodec[C] = {
+    D4SCodec.fromPair(contramap2(another)(encode), map2(another)(decode))
+  }
+  final def imap2[B, C](anotherEnc: D4SEncoder[B], anotherDec: D4SDecoder[B])(decode: (A, B) => C)(encode: C => (A, B)): D4SCodec[C] = {
+    D4SCodec.fromPair(contramap2(anotherEnc)(encode), map2(anotherDec)(decode))
+  }
+  final def imap2[B]: Imap2PartiallyApplied[A, B] = new Imap2PartiallyApplied[A, B](this)
   final def imapObject(
-    to: Map[String, AttributeValue] => Map[String, AttributeValue]
-  )(from: Map[String, AttributeValue] => Map[String, AttributeValue]): D4SCodec[A] = {
-    fromPair(mapObject(to), contramapObject(from))
+    decode: Map[String, AttributeValue] => Map[String, AttributeValue]
+  )(encode: Map[String, AttributeValue] => Map[String, AttributeValue]): D4SCodec[A] = {
+    D4SCodec.fromPair(mapObject(decode), contramapObject(encode))
+  }
+  override final def appendFields[Item: D4SEncoder](f: (A, Map[String, AttributeValue]) => Item): D4SCodec[A] = {
+    D4SCodec.fromPair(super.appendFields(f), this)
   }
 }
 
 object D4SCodec {
-  def apply[A: D4SCodec]: D4SCodec[A]                                    = implicitly
+  @inline def apply[A: D4SCodec]: D4SCodec[A]                            = implicitly
   def derived[A](implicit derivedCodec: D4SDerivedCodec[A]): D4SCodec[A] = D4SCodec.fromPair(derivedCodec.enc, derivedCodec.dec)
 
   def from[T: D4SEncoder: D4SDecoder]: D4SCodec[T] = fromPair(D4SEncoder[T], D4SDecoder[T])
@@ -33,4 +43,10 @@ object D4SCodec {
 
   @deprecated("Use derived", "1.0.3")
   def derive[A](implicit derivedCodec: D4SDerivedCodec[A]): D4SCodec[A] = D4SCodec.fromPair(derivedCodec.enc, derivedCodec.dec)
+
+  final class Imap2PartiallyApplied[A, B](private val self: D4SCodec[A]) extends AnyVal {
+    def apply[C](decode: (A, B) => C)(encode: C => (A, B))(implicit enc: D4SEncoder[B], dec: D4SDecoder[B]): D4SCodec[C] = {
+      self.imap2(enc, dec)(decode)(encode)
+    }
+  }
 }

--- a/d4s/src/main/scala/d4s/codecs/D4SKeyEncoder.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SKeyEncoder.scala
@@ -1,9 +1,20 @@
 package d4s.codecs
 
-trait D4SKeyEncoder[T] {
-  def encode(item: T): String
+import java.util.UUID
+
+trait D4SKeyEncoder[A] {
+  def encode(item: A): String
 }
 
 object D4SKeyEncoder {
-  implicit def simpleTypeEncoder[T]: D4SKeyEncoder[T] = _.toString
+  @inline def apply[A: D4SKeyEncoder]: D4SKeyEncoder[A] = implicitly
+
+  def encode[A: D4SKeyEncoder](item: A): String = D4SKeyEncoder[A].encode(item)
+
+  implicit val stringKeyEncoder: D4SKeyEncoder[String] = identity
+  implicit val byteKeyEncoder: D4SKeyEncoder[Byte]     = _.toString
+  implicit val shortKeyEncoder: D4SKeyEncoder[Short]   = _.toString
+  implicit val intKeyEncoder: D4SKeyEncoder[Int]       = _.toString
+  implicit val longKeyEncoder: D4SKeyEncoder[Long]     = _.toString
+  implicit val uuidKeyEncoder: D4SKeyEncoder[UUID]     = _.toString
 }

--- a/d4s/src/main/scala/d4s/codecs/DynamoKeyAttribute.scala
+++ b/d4s/src/main/scala/d4s/codecs/DynamoKeyAttribute.scala
@@ -10,12 +10,12 @@ final case class DynamoKeyAttribute[T](attrType: ScalarAttributeType)
 object DynamoKeyAttribute {
   def apply[T: DynamoKeyAttribute]: DynamoKeyAttribute[T] = implicitly
 
-  implicit val StringAttribute: DynamoKeyAttribute[String] = new DynamoKeyAttribute[String](ScalarAttributeType.S)
-  implicit val ByteAttribute: DynamoKeyAttribute[Byte]     = new DynamoKeyAttribute[Byte](ScalarAttributeType.N)
-  implicit val ShortAttribute: DynamoKeyAttribute[Short]   = new DynamoKeyAttribute[Short](ScalarAttributeType.N)
-  implicit val IntAttribute: DynamoKeyAttribute[Int]       = new DynamoKeyAttribute[Int](ScalarAttributeType.N)
-  implicit val LongAttribute: DynamoKeyAttribute[Long]     = new DynamoKeyAttribute[Long](ScalarAttributeType.N)
-  implicit val UUIDAttribute: DynamoKeyAttribute[UUID]     = new DynamoKeyAttribute[UUID](ScalarAttributeType.S)
+  implicit val stringAttribute: DynamoKeyAttribute[String] = new DynamoKeyAttribute[String](ScalarAttributeType.S)
+  implicit val byteAttribute: DynamoKeyAttribute[Byte]     = new DynamoKeyAttribute[Byte](ScalarAttributeType.N)
+  implicit val shortAttribute: DynamoKeyAttribute[Short]   = new DynamoKeyAttribute[Short](ScalarAttributeType.N)
+  implicit val intAttribute: DynamoKeyAttribute[Int]       = new DynamoKeyAttribute[Int](ScalarAttributeType.N)
+  implicit val longAttribute: DynamoKeyAttribute[Long]     = new DynamoKeyAttribute[Long](ScalarAttributeType.N)
+  implicit val uuidAttribute: DynamoKeyAttribute[UUID]     = new DynamoKeyAttribute[UUID](ScalarAttributeType.S)
 
   implicit val SdkBytesAttribute: DynamoKeyAttribute[SdkBytes] = new DynamoKeyAttribute[SdkBytes](ScalarAttributeType.B)
 }

--- a/d4s/src/main/scala/d4s/config/DynamoBatchConfig.scala
+++ b/d4s/src/main/scala/d4s/config/DynamoBatchConfig.scala
@@ -5,5 +5,5 @@ import scala.concurrent.duration.FiniteDuration
 final case class DynamoBatchConfig(
   unprocessedBatchSleep: Option[FiniteDuration],
   writeBatchSize: Int,
-  getBatchSize: Int
+  getBatchSize: Int,
 )

--- a/d4s/src/main/scala/d4s/models/FieldOps.scala
+++ b/d4s/src/main/scala/d4s/models/FieldOps.scala
@@ -14,14 +14,6 @@ trait FieldOps {
 
 object FieldOps {
 
-  final class PathBasedFieldOpsCtor(private val path: List[String]) extends AnyVal {
-    def of[T]: TypedFieldOps[T] = new TypedFieldOps[T](path)
-
-    def existsField: Condition.attribute_exists           = Condition.attribute_exists(path)
-    def notExists: Condition.attribute_not_exists         = Condition.attribute_not_exists(path)
-    def beginsWith(substr: String): Condition.begins_with = Condition.begins_with(path, substr)
-  }
-
   final class StringTypedFieldOpsCtor(private val name: String) extends AnyVal {
     def of[T]: TypedFieldOps[T] = new TypedFieldOps[T](List(name))
 
@@ -29,13 +21,31 @@ object FieldOps {
 
     def existsField: Condition.attribute_exists           = Condition.attribute_exists(List(name))
     def notExists: Condition.attribute_not_exists         = Condition.attribute_not_exists(List(name))
+    def hasType(tpe: String): Condition.attribute_type    = Condition.attribute_type(List(name), tpe)
+    def sizeField: Condition.size                         = Condition.size(List(name))
     def beginsWith(substr: String): Condition.begins_with = Condition.begins_with(List(name), substr)
+  }
+
+  final class PathBasedFieldOpsCtor(private val path: List[String]) extends AnyVal {
+    def of[T]: TypedFieldOps[T] = new TypedFieldOps[T](path)
+
+    def existsField: Condition.attribute_exists           = Condition.attribute_exists(path)
+    def notExists: Condition.attribute_not_exists         = Condition.attribute_not_exists(path)
+    def hasType(tpe: String): Condition.attribute_type    = Condition.attribute_type(path, tpe)
+    def sizeField: Condition.size                         = Condition.size(path)
+    def beginsWith(substr: String): Condition.begins_with = Condition.begins_with(path, substr)
   }
 
   final class TypedFieldOps[T](private val path: List[String]) extends AnyVal {
     def exists: Condition.attribute_exists                = Condition.attribute_exists(path)
     def notExists: Condition.attribute_not_exists         = Condition.attribute_not_exists(path)
+    def hasType(tpe: String): Condition.attribute_type    = Condition.attribute_type(path, tpe)
+    def size: Condition.size                              = Condition.size(path)
     def beginsWith(substr: String): Condition.begins_with = Condition.begins_with(path, substr)
+
+    def contains(value: T)(implicit enc: D4SAttributeEncoder[T]): Condition.contains[T] = {
+      Condition.contains(path, value)
+    }
 
     def isIn(set: Set[T])(implicit enc: D4SAttributeEncoder[T]): Condition.in[T] = {
       Condition.in(path, set)

--- a/d4s/src/main/scala/d4s/package.scala
+++ b/d4s/src/main/scala/d4s/package.scala
@@ -1,0 +1,6 @@
+import zio.Has
+
+package object d4s {
+  type DynamoConnector3[F[-_, +_, +_]]   = DynamoConnector[F[Any, +?, +?]]
+  type HasDynamoConnector[F[-_, +_, +_]] = Has[DynamoConnector[F[Any, +?, +?]]]
+}


### PR DESCRIPTION
* Fix #24 add `attribute_type`, `contains` and `size` condition expressions, unprivate `createAlias`
* Add binary set, string set, number set codecs
* move `d4z` to new zio environment encoding
* add D4SEncoder/D4SCodec.appendFields
* add better syntax for D4SCodec.imap2
* deduplicate decoders
* restrict D4SKeyEncoder to the same types as KeyDecoder, add byte & long codecs