### PR TITLE
Multiple changes; update to izumi 0.10.15

### DIFF
--- a/d4s/src/main/scala/d4s/DynamoConnector.scala
+++ b/d4s/src/main/scala/d4s/DynamoConnector.scala
@@ -13,7 +13,7 @@ import izumi.fundamentals.platform.language.unused
 import logstage.LogBIO
 import net.playq.metrics.Metrics
 
-trait DynamoConnector[F[+_, +_]] {
+trait DynamoConnector[F[_, _]] {
   def runUnrecorded[DR <: DynamoRequest, A](q: DynamoExecution[DR, _, A]): F[DynamoException, A]
   def runUnrecorded[DR <: DynamoRequest, A](q: DynamoExecution.Streamed[DR, _, A]): Stream[F[DynamoException, ?], A]
 

--- a/d4s/src/main/scala/d4s/codecs/D4SAttributeCodec.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SAttributeCodec.scala
@@ -10,7 +10,7 @@ trait D4SAttributeCodec[A] extends D4SAttributeEncoder[A] with D4SDecoder[A] {
 }
 
 object D4SAttributeCodec {
-  @inline def apply[A: D4SAttributeCodec]: D4SAttributeCodec[A] = implicitly
+  @inline def apply[A](implicit ev: D4SAttributeCodec[A]): ev.type = ev
 
   def derived[A](implicit derivedCodec: D4SDerivedAttributeCodec[A]): D4SAttributeCodec[A] = D4SAttributeCodec.fromPair(derivedCodec.enc, derivedCodec.dec)
 

--- a/d4s/src/main/scala/d4s/codecs/D4SCodec.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SCodec.scala
@@ -26,7 +26,7 @@ trait D4SCodec[A] extends D4SAttributeCodec[A] with D4SEncoder[A] {
 }
 
 object D4SCodec {
-  @inline def apply[A: D4SCodec]: D4SCodec[A] = implicitly
+  @inline def apply[A](implicit ev: D4SCodec[A]): ev.type = ev
 
   def derived[A](implicit derivedCodec: D4SDerivedCodec[A]): D4SCodec[A] = D4SCodec.fromPair(derivedCodec.enc, derivedCodec.dec)
 

--- a/d4s/src/main/scala/d4s/codecs/D4SDecoder.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SDecoder.scala
@@ -37,7 +37,7 @@ trait D4SDecoder[T] {
 }
 
 object D4SDecoder extends D4SDecoderScala213 {
-  @inline def apply[A: D4SDecoder]: D4SDecoder[A] = implicitly
+  @inline def apply[A](implicit ev: D4SDecoder[A]): ev.type = ev
 
   def derived[A]: D4SDecoder[A] = macro Magnolia.gen[A]
 

--- a/d4s/src/main/scala/d4s/codecs/D4SEncoder.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SEncoder.scala
@@ -26,7 +26,7 @@ trait D4SEncoder[A] extends D4SAttributeEncoder[A] {
 }
 
 object D4SEncoder {
-  @inline def apply[A: D4SEncoder]: D4SEncoder[A] = implicitly
+  @inline def apply[A](implicit ev: D4SEncoder[A]): ev.type = ev
 
   def derived[A]: D4SEncoder[A] = macro Magnolia.gen[A]
 

--- a/d4s/src/main/scala/d4s/codecs/D4SKeyDecoder.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SKeyDecoder.scala
@@ -12,7 +12,7 @@ trait D4SKeyDecoder[A] {
 }
 
 object D4SKeyDecoder {
-  @inline def apply[A: D4SKeyDecoder]: D4SKeyDecoder[A] = implicitly
+  @inline def apply[A](implicit ev: D4SKeyDecoder[A]): ev.type = ev
 
   def decode[A: D4SKeyDecoder](item: String): Either[DecoderException, A] = D4SKeyDecoder[A].decode(item)
 

--- a/d4s/src/main/scala/d4s/codecs/D4SKeyEncoder.scala
+++ b/d4s/src/main/scala/d4s/codecs/D4SKeyEncoder.scala
@@ -7,7 +7,7 @@ trait D4SKeyEncoder[A] {
 }
 
 object D4SKeyEncoder {
-  @inline def apply[A: D4SKeyEncoder]: D4SKeyEncoder[A] = implicitly
+  @inline def apply[A](implicit ev: D4SKeyEncoder[A]): ev.type = ev
 
   def encode[A: D4SKeyEncoder](item: A): String = D4SKeyEncoder[A].encode(item)
 

--- a/d4s/src/main/scala/d4s/codecs/DynamoKeyAttribute.scala
+++ b/d4s/src/main/scala/d4s/codecs/DynamoKeyAttribute.scala
@@ -5,18 +5,29 @@ import java.util.UUID
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
-final case class DynamoKeyAttribute[T](attrType: ScalarAttributeType)
+trait DynamoKeyAttribute[T] {
+  def attrType: ScalarAttributeType
+}
 
 object DynamoKeyAttribute {
   def apply[T: DynamoKeyAttribute]: DynamoKeyAttribute[T] = implicitly
 
-  implicit val stringAttribute: DynamoKeyAttribute[String] = new DynamoKeyAttribute[String](ScalarAttributeType.S)
-  implicit val byteAttribute: DynamoKeyAttribute[Byte]     = new DynamoKeyAttribute[Byte](ScalarAttributeType.N)
-  implicit val shortAttribute: DynamoKeyAttribute[Short]   = new DynamoKeyAttribute[Short](ScalarAttributeType.N)
-  implicit val intAttribute: DynamoKeyAttribute[Int]       = new DynamoKeyAttribute[Int](ScalarAttributeType.N)
-  implicit val longAttribute: DynamoKeyAttribute[Long]     = new DynamoKeyAttribute[Long](ScalarAttributeType.N)
-  implicit val uuidAttribute: DynamoKeyAttribute[UUID]     = new DynamoKeyAttribute[UUID](ScalarAttributeType.S)
+  def apply[T](scalarAttributeType: ScalarAttributeType): DynamoKeyAttribute[T] = new DynamoKeyAttribute[T] {
+    override def attrType: ScalarAttributeType = scalarAttributeType
+  }
 
-  implicit val sdkBytesAttribute: DynamoKeyAttribute[SdkBytes]     = new DynamoKeyAttribute[SdkBytes](ScalarAttributeType.B)
-  implicit val arrayByteAttribute: DynamoKeyAttribute[Array[Byte]] = new DynamoKeyAttribute[Array[Byte]](ScalarAttributeType.B)
+  def S[T]: DynamoKeyAttribute[T] = DynamoKeyAttribute(ScalarAttributeType.S)
+  def N[T]: DynamoKeyAttribute[T] = DynamoKeyAttribute(ScalarAttributeType.N)
+  def B[T]: DynamoKeyAttribute[T] = DynamoKeyAttribute(ScalarAttributeType.B)
+
+  implicit val stringAttribute: DynamoKeyAttribute[String] = DynamoKeyAttribute.S
+  implicit val uuidAttribute: DynamoKeyAttribute[UUID]     = DynamoKeyAttribute.S
+
+  implicit val byteAttribute: DynamoKeyAttribute[Byte]   = DynamoKeyAttribute.N
+  implicit val shortAttribute: DynamoKeyAttribute[Short] = DynamoKeyAttribute.N
+  implicit val intAttribute: DynamoKeyAttribute[Int]     = DynamoKeyAttribute.N
+  implicit val longAttribute: DynamoKeyAttribute[Long]   = DynamoKeyAttribute.N
+
+  implicit val sdkBytesAttribute: DynamoKeyAttribute[SdkBytes]     = DynamoKeyAttribute.B
+  implicit val arrayByteAttribute: DynamoKeyAttribute[Array[Byte]] = DynamoKeyAttribute.B
 }

--- a/d4s/src/main/scala/d4s/d4z.scala
+++ b/d4s/src/main/scala/d4s/d4z.scala
@@ -2,4 +2,4 @@ package d4s
 
 import zio.ZIO
 
-object d4z extends DynamoConnectorLocal[ZIO]
+object d4z extends DynamoConnectorEnv[ZIO]

--- a/d4s/src/main/scala/d4s/implicits.scala
+++ b/d4s/src/main/scala/d4s/implicits.scala
@@ -1,5 +1,5 @@
 package d4s
 
-import d4s.models.FieldOps
+import d4s.models.StringFieldOps
 
-object implicits extends FieldOps
+object implicits extends StringFieldOps

--- a/d4s/src/main/scala/d4s/keys/OrderedTimestampKey.scala
+++ b/d4s/src/main/scala/d4s/keys/OrderedTimestampKey.scala
@@ -4,7 +4,6 @@ import java.time.{LocalDateTime, ZonedDateTime}
 
 import d4s.codecs.{D4SAttributeEncoder, D4SDecoder, DynamoKeyAttribute}
 import izumi.fundamentals.platform.time.IzTime
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
 /**
   * A string representation of ZonedDateTime that preserves its native ordering
@@ -27,7 +26,7 @@ object OrderedTimestampKey {
   implicit val encoder: D4SAttributeEncoder[OrderedTimestampKey] = D4SAttributeEncoder[String].contramap(_.asString)
   implicit val decoder: D4SDecoder[OrderedTimestampKey]          = D4SDecoder[String].map(OrderedTimestampKey(_))
 
-  implicit val keyAttribute: DynamoKeyAttribute[OrderedTimestampKey] = new DynamoKeyAttribute[OrderedTimestampKey](ScalarAttributeType.S)
+  implicit val keyAttribute: DynamoKeyAttribute[OrderedTimestampKey] = DynamoKeyAttribute.S
 
   implicit val ordering: Ordering[OrderedTimestampKey] = Ordering[String].on(_.asString)
 }

--- a/d4s/src/main/scala/d4s/keys/OrderedUUIDKey.scala
+++ b/d4s/src/main/scala/d4s/keys/OrderedUUIDKey.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import d4s.codecs.{D4SAttributeEncoder, D4SDecoder, DynamoKeyAttribute}
 import d4s.util.leftpadLongInvertNegative
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
 /**
   * A string representation of UUID that preserves UUID and TimeUUID native ordering
@@ -26,7 +25,7 @@ object OrderedUUIDKey {
   implicit val encoder: D4SAttributeEncoder[OrderedUUIDKey] = D4SAttributeEncoder[String].contramap(_.asString)
   implicit val decoder: D4SDecoder[OrderedUUIDKey]          = D4SDecoder[String].map(OrderedUUIDKey(_))
 
-  implicit val keyAttribute: DynamoKeyAttribute[OrderedUUIDKey] = new DynamoKeyAttribute[OrderedUUIDKey](ScalarAttributeType.S)
+  implicit val keyAttribute: DynamoKeyAttribute[OrderedUUIDKey] = DynamoKeyAttribute.S
 
   implicit val ordering: Ordering[OrderedUUIDKey] = Ordering[String].on(_.asString)
 }

--- a/d4s/src/main/scala/d4s/keys/ReversedTimestampKey.scala
+++ b/d4s/src/main/scala/d4s/keys/ReversedTimestampKey.scala
@@ -5,7 +5,6 @@ import java.time.ZonedDateTime
 import d4s.codecs.{D4SAttributeEncoder, D4SDecoder, DynamoKeyAttribute}
 import d4s.util.negateDigits
 import izumi.fundamentals.platform.language.Quirks
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
 /** A [[OrderedTimestampKey]] rendered with inverted digits to reverse range key ordering in DynamoDB */
 final case class ReversedTimestampKey private (asString: String) extends AnyVal
@@ -24,7 +23,7 @@ object ReversedTimestampKey {
   implicit val encoder: D4SAttributeEncoder[ReversedTimestampKey] = D4SAttributeEncoder[String].contramap(_.asString)
   implicit val decoder: D4SDecoder[ReversedTimestampKey]          = D4SDecoder[String].map(ReversedTimestampKey(_))
 
-  implicit val keyAttribute: DynamoKeyAttribute[ReversedTimestampKey] = new DynamoKeyAttribute[ReversedTimestampKey](ScalarAttributeType.S)
+  implicit val keyAttribute: DynamoKeyAttribute[ReversedTimestampKey] = DynamoKeyAttribute.S
 
   implicit val ordering: Ordering[ReversedTimestampKey] = Ordering[String].on(_.asString)
 }

--- a/d4s/src/main/scala/d4s/keys/ReversedUUIDKey.scala
+++ b/d4s/src/main/scala/d4s/keys/ReversedUUIDKey.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import d4s.codecs.{D4SAttributeEncoder, D4SDecoder, DynamoKeyAttribute}
 import d4s.util.{negateDigits, negateMinus}
 import izumi.fundamentals.platform.language.Quirks
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 
 /** An [[OrderedUUIDKey]] rendered with inverted digits and minus sign to reverse range key ordering in DynamoDB */
 final case class ReversedUUIDKey private (asString: String) extends AnyVal
@@ -24,7 +23,7 @@ object ReversedUUIDKey {
   implicit val encoder: D4SAttributeEncoder[ReversedUUIDKey] = D4SAttributeEncoder[String].contramap(_.asString)
   implicit val decoder: D4SDecoder[ReversedUUIDKey]          = D4SDecoder[String].map(ReversedUUIDKey(_))
 
-  implicit val keyAttribute: DynamoKeyAttribute[ReversedUUIDKey] = new DynamoKeyAttribute[ReversedUUIDKey](ScalarAttributeType.S)
+  implicit val keyAttribute: DynamoKeyAttribute[ReversedUUIDKey] = DynamoKeyAttribute.S
 
   implicit val ordering: Ordering[ReversedUUIDKey] = Ordering[String].on(_.asString)
 }

--- a/d4s/src/main/scala/d4s/models/DynamoException.scala
+++ b/d4s/src/main/scala/d4s/models/DynamoException.scala
@@ -2,17 +2,18 @@ package d4s.models
 
 import scala.annotation.tailrec
 
-abstract class DynamoException(val message: String, val cause: Throwable) extends RuntimeException(message, cause)
+abstract class DynamoException(val message: String, val cause: Throwable) extends RuntimeException(message, cause) {
+  require(cause ne null)
+}
 
 object DynamoException {
-  @tailrec def unapply(arg: DynamoException): Option[(String, Throwable)] = shallow.unapply(arg) match {
-    case Some((_, inner: DynamoException)) => unapply(inner)
-    case None                              => None
-    case res                               => res
+  @tailrec def unapply(arg: DynamoException): Some[(String, Throwable)] = arg.cause match {
+    case inner: DynamoException => unapply(inner)
+    case otherCause             => Some(arg.message, otherCause)
   }
 
   object shallow {
-    def unapply(arg: DynamoException): Option[(String, Throwable)] = Some((arg.message, arg.cause))
+    def unapply(arg: DynamoException): Some[(String, Throwable)] = Some((arg.message, arg.cause))
   }
 
   final case class InterpreterException(operation: String, tableName: Option[String], override val cause: Throwable)

--- a/d4s/src/main/scala/d4s/models/DynamoException.scala
+++ b/d4s/src/main/scala/d4s/models/DynamoException.scala
@@ -9,7 +9,7 @@ abstract class DynamoException(val message: String, val cause: Throwable) extend
 object DynamoException {
   @tailrec def unapply(arg: DynamoException): Some[(String, Throwable)] = arg.cause match {
     case inner: DynamoException => unapply(inner)
-    case otherCause             => Some(arg.message, otherCause)
+    case otherCause             => Some((arg.message, otherCause))
   }
 
   object shallow {

--- a/d4s/src/main/scala/d4s/models/DynamoExecution.scala
+++ b/d4s/src/main/scala/d4s/models/DynamoExecution.scala
@@ -221,6 +221,7 @@ object DynamoExecution {
 
         def go(rsp: DR#Rsp, rows: Queue[Dec]): F[Throwable, List[A]] = {
           val lastEvaluatedKey = paging.getPageMarker(rsp)
+
           def stop = {
             val res = f(rows.toList)
             F.pure(limit.fold(res)(res.take))

--- a/d4s/src/main/scala/d4s/models/StringFieldOps.scala
+++ b/d4s/src/main/scala/d4s/models/StringFieldOps.scala
@@ -1,18 +1,18 @@
 package d4s.models
 
 import d4s.codecs.{D4SAttributeEncoder, DynamoKeyAttribute}
-import d4s.models.FieldOps.{PathBasedFieldOpsCtor, StringTypedFieldOpsCtor}
+import d4s.models.StringFieldOps.{PathBasedFieldOpsCtor, StringTypedFieldOpsCtor}
 import d4s.models.conditions._
 import d4s.models.table.DynamoField
 
 import scala.language.implicitConversions
 
-trait FieldOps {
+trait StringFieldOps {
   @inline implicit final def stringToTypedFieldOps(s: String): StringTypedFieldOpsCtor = new StringTypedFieldOpsCtor(s)
   @inline implicit final def pathToFieldOps(path: List[String]): PathBasedFieldOpsCtor = new PathBasedFieldOpsCtor(path)
 }
 
-object FieldOps {
+object StringFieldOps {
 
   final class StringTypedFieldOpsCtor(private val name: String) extends AnyVal {
     def of[T]: TypedFieldOps[T] = new TypedFieldOps[T](List(name))

--- a/d4s/src/main/scala/d4s/models/query/DynamoQuery.scala
+++ b/d4s/src/main/scala/d4s/models/query/DynamoQuery.scala
@@ -14,7 +14,6 @@ import d4s.models.table.index.{GlobalIndexUpdate, ProvisionedGlobalIndex, TableI
 import d4s.models.table.{DynamoField, TableDDL, TableReference}
 import d4s.models.{DynamoExecution, FnBIO, OffsetLimit}
 import izumi.functional.bio.{BIO, BIOError, F}
-import izumi.fundamentals.platform.language.unused
 import software.amazon.awssdk.services.dynamodb.model.{AttributeValue, ConsumedCapacity, ReturnValue, Select}
 
 import scala.language.{implicitConversions, reflectiveCalls}
@@ -257,12 +256,11 @@ object DynamoQuery {
     def withTtlFieldOption(expiration: Option[ZonedDateTime]): DynamoQuery[DR, Dec] =
       expiration.fold(dynamoQuery)(withTtlField)
 
-    def withTtlFieldOption(
-      expirationEpochSeconds: Option[Long]
-    )(implicit ev: DR <:< WithItem[DR] with WithTableReference[DR],
-      @unused dummy: DummyImplicit,
-    ): DynamoQuery[DR, Dec] = {
-      expirationEpochSeconds.fold(dynamoQuery)(withTtlField)
+    def withTtlFieldOption(expirationEpochSeconds: Option[Long])(implicit dummy: DummyImplicit): DynamoQuery[DR, Dec] = {
+      expirationEpochSeconds match {
+        case Some(expiration) => withTtlField(expiration)
+        case None             => dynamoQuery
+      }
     }
 
     def withTtlField(expiration: ZonedDateTime): DynamoQuery[DR, Dec] =

--- a/d4s/src/main/scala/d4s/models/table/DynamoField.scala
+++ b/d4s/src/main/scala/d4s/models/table/DynamoField.scala
@@ -1,7 +1,7 @@
 package d4s.models.table
 
 import d4s.codecs.{D4SAttributeEncoder, DynamoKeyAttribute}
-import d4s.models.FieldOps.TypedFieldOps
+import d4s.models.StringFieldOps.TypedFieldOps
 import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, AttributeValue, ScalarAttributeType}
 
 import scala.language.implicitConversions

--- a/d4s/src/main/scala/d4s/models/table/DynamoKey.scala
+++ b/d4s/src/main/scala/d4s/models/table/DynamoKey.scala
@@ -31,11 +31,11 @@ final case class DynamoKey[-H, -R](
   def bind(hashValue: H, rangeValue: R): Map[String, AttributeValue] = bind(hashValue, Some(rangeValue))
   def bind(hashValue: H): Map[String, AttributeValue]                = bind(hashValue, None)
 
-  def contramapHash[H1](f: H1 => H): DynamoKey[H1, R]     = copy(hashKey  = hashKey.contramap(f))
-  def contramapRange[R1](f: R1 => R): DynamoKey[H, R1]    = copy(rangeKey = rangeKey.map(_.contramap(f)))
-  def contramapBoth[X](f: X => H with R): DynamoKey[X, X] = copy(hashKey  = hashKey.contramap(f), rangeKey = rangeKey.map(_.contramap(f)))
+  def contramapHash[H1](f: H1 => H): DynamoKey[H1, R]                  = copy(hashKey = hashKey.contramap(f))
+  def contramapRange[R1](f: R1 => R): DynamoKey[H, R1]                 = copy(rangeKey = rangeKey.map(_.contramap(f)))
+  def contramapBoth[H1, R1](f: H1 => H, g: R1 => R): DynamoKey[H1, R1] = copy(hashKey = hashKey.contramap(f), rangeKey = rangeKey.map(_.contramap(g)))
 
-  private def element(name: String, tpe: KeyType): KeySchemaElement = {
+  private[this] def element(name: String, tpe: KeyType): KeySchemaElement = {
     KeySchemaElement.builder().attributeName(name).keyType(tpe).build()
   }
 }

--- a/d4s/src/main/scala/d4s/models/table/TableReference.scala
+++ b/d4s/src/main/scala/d4s/models/table/TableReference.scala
@@ -106,13 +106,14 @@ object TableReference {
     def updateTags(arn: String, tagsToUpdate: Map[String, String]): DynamoQuery[UpdateTableTags, TagResourceResponse] = UpdateTableTags(table, arn, tagsToUpdate).toQuery
     def markForDeletion(arn: String): DynamoQuery[UpdateTableTags, TagResourceResponse]                               = UpdateTableTags(table, arn, Map(SharedTags.markedForDeletion)).toQuery
 
-    def query: DynamoQuery[Query, QueryResponse]                                                            = Query(table).toQuery
-    def query(index: TableIndex[_, _]): DynamoQuery[Query, QueryResponse]                                   = Query(table).withIndex(index).toQuery
-    def query(key: Map[String, AttributeValue]): DynamoQuery[Query, QueryResponse]                          = Query(table).withKey(key).toQuery
+    def query: DynamoQuery[Query, QueryResponse]                                   = Query(table).toQuery
+    def query(index: TableIndex[_, _]): DynamoQuery[Query, QueryResponse]          = Query(table).withIndex(index).toQuery
+    def query(key: Map[String, AttributeValue]): DynamoQuery[Query, QueryResponse] = Query(table).withKey(key).toQuery
+    @deprecated("Use .query(index).withKey(key)", "1.0.8")
     def query(index: TableIndex[_, _], key: Map[String, AttributeValue]): DynamoQuery[Query, QueryResponse] = Query(table).withIndex(index).withKey(key).toQuery
     def query[H](index: TableIndex[H, _], hashKey: H): DynamoQuery[Query, QueryResponse]                    = Query(table).withIndex(index).withKeyField(index.key.hashKey)(hashKey).toQuery
-    def query[H, R](index: TableIndex[H, R], hashKey: H, rangeKey: R): DynamoQuery[Query, QueryResponse]    = Query(table).withIndex(index).withKey(index.key.bind(hashKey, rangeKey)).toQuery
-
+    def query[H, R](index: TableIndex[H, R], hashKey: H, rangeKey: R): DynamoQuery[Query, QueryResponse] =
+      Query(table).withIndex(index).withKey(index.key.bind(hashKey, rangeKey)).toQuery
 
     def queryDeleteBatch: DynamoQuery[QueryDeleteBatch, List[BatchWriteItemResponse]]                          = QueryDeleteBatch(table).toQuery
     def queryDeleteBatch(maxParallelDeletes: Int): DynamoQuery[QueryDeleteBatch, List[BatchWriteItemResponse]] = QueryDeleteBatch(table, Some(maxParallelDeletes)).toQuery
@@ -120,6 +121,7 @@ object TableReference {
       QueryDeleteBatch(table).withIndex(index).toQuery
     def queryDeleteBatch(key: Map[String, AttributeValue]): DynamoQuery[QueryDeleteBatch, List[BatchWriteItemResponse]] =
       QueryDeleteBatch(table).withKey(key).toQuery
+    @deprecated("Use .queryDeleteBatch(index).withKey(key)", "1.0.8")
     def queryDeleteBatch(index: TableIndex[_, _], key: Map[String, AttributeValue]): DynamoQuery[QueryDeleteBatch, List[BatchWriteItemResponse]] =
       QueryDeleteBatch(table).withIndex(index).withKey(key).toQuery
     def queryDeleteBatch[H](index: TableIndex[H, _], hashKey: H): DynamoQuery[QueryDeleteBatch, List[BatchWriteItemResponse]] =

--- a/d4s/src/main/scala_2.12/d4s/codecs/D4SAttributeEncoderScala213.scala
+++ b/d4s/src/main/scala_2.12/d4s/codecs/D4SAttributeEncoderScala213.scala
@@ -1,3 +1,0 @@
-package d4s.codecs
-
-trait D4SAttributeEncoderScala213

--- a/d4s/src/main/scala_2.13/d4s/codecs/D4SAttributeEncoderScala213.scala
+++ b/d4s/src/main/scala_2.13/d4s/codecs/D4SAttributeEncoderScala213.scala
@@ -1,9 +1,0 @@
-package d4s.codecs
-
-trait D4SAttributeEncoderScala213 {
-
-  implicit def literalTupleEncoder[S <: String, V: D4SAttributeEncoder]: D4SEncoder[(S, V)] = {
-    case (k, v) => D4SAttributeEncoder.encodeField(k, v)
-  }
-
-}

--- a/metrics/src/main/scala/net/playq/metrics/MetricsExtractor.scala
+++ b/metrics/src/main/scala/net/playq/metrics/MetricsExtractor.scala
@@ -26,7 +26,7 @@ final class MetricsExtractor(rolesInfo: RolesInfo, logger: IzLogger) {
       val (errors, rawFetched) = resourceList.asScala.toList.flatMap {
         case res if !res.getPath.endsWith("metrics.json") =>
           val filename = res.getPath
-          logger.crit(s"Found a junk file with $filename in $metricsDir - filename does not end with `metrics.json`, Skipping.")
+          logger.crit(s"Found a junk file with $filename in ${metricsDir -> "metricsDir"} - filename does not end with `metrics.json`, Skipping.")
           Nil
         case res =>
           val bytes   = res.load()

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,7 +1,7 @@
 object V {
   val scala_212     = "2.12.11"
   val scala_213     = "2.13.2"
-  val izumi_version = "0.10.13"
+  val izumi_version = "0.10.15"
 
   // compiler
   val kind_projector = "0.11.0"


### PR DESCRIPTION
* Update to izumi 0.10.15
* Add `DynamoExecution#eitherConditionSuccess`
* rework DynamoKeyAttribute. `trait`->`class`, add convenience constructors `.S`, `.N`, `.B`
* replace `DynamoKey.contramapBoth` with a more useful version
* make `stringTupleEncoder` available on 2.12 (only decoder requires 2.13+)
* rename `DynamoConnectorLocal`->`DynamoConnectorEnv`, require less capabilities (`BIOLocal`->`BIOMonadAsk`)
* deprecate `query` & `queryDeleteBatch` overloads indexes & untyped keys